### PR TITLE
Implementer email reminder management command and endorse emails change managers

### DIFF
--- a/registers/management/commands/rfc_email_implementers_reminder.py
+++ b/registers/management/commands/rfc_email_implementers_reminder.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from pytz import timezone
+from registers.models import ChangeRequest, ChangeLog
+
+
+class Command(BaseCommand):
+    help = 'Emails implementers a request to record completion of any outstanding change requests.'
+
+    def handle(self, *args, **options):
+        # All changes of status "Ready", where the planned_end datetime has passed and completed datetime is null:
+        rfcs = ChangeRequest.objects.filter(
+            status=3, planned_end__lte=datetime.now().astimezone(timezone(settings.TIME_ZONE)), completed__isnull=True)
+
+        #null check
+        if rfcs.count() > 0:
+            for rfc in rfcs:
+                #send email
+                subject = 'Completion of change request {}'.format(rfc)
+                text_content = """This is an automated message to let you know that you are recorded as the
+                    implementer for change request {}, scheduled to be undertaken on {}.\n
+                    Please visit the following URL and record the outcome of the change in order to finalise it:\n
+                    {}\n
+                    """.format(rfc, rfc.planned_start.astimezone().strftime('%d/%b/%Y at %H:%M'), rfc.get_absolute_url())
+                html_content = """<p>This is an automated message to let you know that you are recorded as the
+                    implementer for change request {0}, scheduled to be undertaken on {1}.</p>
+                    <p>Please visit the following URL and record the outcome of the change in order to finalise it:</p>
+                    <ul><li><a href="{2}">{2}</a></li></ul>
+                    """.format(rfc, rfc.planned_start.astimezone().strftime('%d/%b/%Y at %H:%M'), rfc.get_absolute_url())
+                msg = EmailMultiAlternatives(subject, text_content, settings.NOREPLY_EMAIL, [rfc.implementer.email])
+                msg.attach_alternative(html_content, 'text/html')
+                msg.send()
+                
+                #create changelog
+                msg = '''Reminder of incomplete change: {} sent to assigned implementer: {} on: {}
+                    '''.format(rfc, rfc.implementer.get_full_name(), datetime.now().astimezone().strftime('%d/%b/%Y at %H:%M'))
+                log = ChangeLog(change_request=rfc, log=msg)
+                log.save()

--- a/registers/views.py
+++ b/registers/views.py
@@ -4,6 +4,7 @@ from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.models import Group, User
 from django.core.mail import EmailMultiAlternatives
 from django.urls import reverse
 from django.http import HttpResponse, HttpResponseRedirect
@@ -368,6 +369,18 @@ class ChangeRequestEndorse(LoginRequiredMixin, UpdateView):
             msg = EmailMultiAlternatives(subject, text_content, settings.NOREPLY_EMAIL, [rfc.requester.email])
             msg.attach_alternative(html_content, 'text/html')
             msg.send()
+
+            #email changeManger/s
+            if  User.objects.filter(groups__name='Change Managers').exists():
+                changeManagers = User.objects.filter(groups__name='Change Managers')
+                if changeManagers.count() > 0:
+                    for i in changeManagers:
+                        #send email
+                        eAddress = i.email
+                        msg = EmailMultiAlternatives(subject, text_content, settings.NOREPLY_EMAIL, [eAddress])
+                        msg.attach_alternative(html_content, 'text/html')
+                        msg.send()
+
         elif self.request.POST.get('reject'):
             # If the user clicked "Reject", log this and change status back to Draft.
             rfc.status = 0

--- a/registers/views.py
+++ b/registers/views.py
@@ -208,7 +208,7 @@ class ChangeRequestChange(LoginRequiredMixin, UpdateView):
         if not rfc.is_draft:
             # Redirect to the object detail view.
             return HttpResponseRedirect(rfc.get_absolute_url())
-        return super(ChangeRequestChange, self)
+        return super(ChangeRequestChange, self).get(request, *args, **kwargs)
 
     def get_form_class(self):
         rfc = self.get_object()


### PR DESCRIPTION
New functionality:
new management command for emailing implementers after scheduled completion.
endorsing a change will now email the 'Change Managers' group (this group requires manual creation).

Files modified:
registers/views.py

Files added:
registers/management/commands/rfc_email_implementers_reminder.py