### PR TITLE
IT System Register API Tweaks

### DIFF
--- a/itsystems/tests/test_api.py
+++ b/itsystems/tests/test_api.py
@@ -56,19 +56,15 @@ class ITSystemRecordAPIResourceTestCase(ApiTestCase):
         # Tests changing the name of an existing record
         old_name = self.record1.name
         new_name = old_name[:-5] + "added_string"
-
         url = reverse("it_system_api_resource", kwargs={"system_id": self.record1.system_id})
         response = self.client.post(path=url, data=json.dumps({"name": new_name}), secure=False, content_type="application/json")
-
         self.record1 = ITSystemRecord.objects.get(pk=self.record1.pk)
         self.assertContains(response, status_code=200, text=new_name)
         self.assertNotContains(response, old_name)
         self.assertEqual(self.record1.name, new_name)
-
         # confirms modified by behaviour
         self.assertEqual(self.record1.modified_by, self.testuser.email)
         self.assertNotEqual(self.record1.created_by, self.testuser.email)
-
         # confirms that a new version was created
         versions = Version.objects.get_for_object(self.record1)
         self.assertEqual(len(versions), 1)
@@ -79,15 +75,12 @@ class ITSystemRecordAPIResourceTestCase(ApiTestCase):
         old_division_id = self.record1.division.id
         new_division = self.record2.division.name
         new_division_id = self.record2.division.id
-
         url = reverse("it_system_api_resource", kwargs={"system_id": self.record1.system_id})
         response = self.client.post(path=url, data=json.dumps({"division": new_division}), secure=False, content_type="application/json")
-
         self.record1 = ITSystemRecord.objects.get(pk=self.record1.pk)
         self.assertContains(response, status_code=200, text=new_division)
         self.assertNotContains(response, old_division)
         self.assertEqual(self.record1.division.name, new_division)
-
         # confirms that a new version was created
         versions = Version.objects.get_for_object(self.record1)
         self.assertEqual(len(versions), 2)
@@ -97,10 +90,8 @@ class ITSystemRecordAPIResourceTestCase(ApiTestCase):
         # Tests changing the name of a record that doesn't exist
         old_name = self.record1.name
         new_name = old_name + "ADDED_STRING"
-
         url = reverse("it_system_api_resource", kwargs={"system_id": self.record1.system_id + "ADDED_STRING"})
         response = self.client.post(path=url, data=json.dumps({"name": new_name}), secure=False, content_type="application/json")
-
         self.record1 = ITSystemRecord.objects.get(pk=self.record1.pk)
         self.assertContains(response=response, status_code=400, text="Can't find system ")
         self.assertEqual(self.record1.name, old_name)
@@ -108,10 +99,8 @@ class ITSystemRecordAPIResourceTestCase(ApiTestCase):
         # Tests changing an FK field of an existing record to one that doesn't exist
         old_division = self.record1.division.name
         fake_division = self.record1.division.name + "ADDED_STRING"
-
         url = reverse("it_system_api_resource", kwargs={"system_id": self.record1.system_id})
         response = self.client.post(path=url, data=json.dumps({"division": fake_division}), secure=False, content_type="application/json")
-
         self.record1 = ITSystemRecord.objects.get(pk=self.record1.pk)
         self.assertContains(response, status_code=400, text="Invalid field value in choice field")
         self.assertEqual(self.record1.division.name, old_division)
@@ -119,10 +108,35 @@ class ITSystemRecordAPIResourceTestCase(ApiTestCase):
         # Tests that attempting to change a field that doesn't exist doesn't change the record at all
         url = reverse("it_system_api_resource", kwargs={"system_id": self.record1.system_id})
         response = self.client.post(path=url, data=json.dumps({"fake_field": "fake_value"}), secure=False, content_type="application/json")
-
         self.record1 = ITSystemRecord.objects.get(pk=self.record1.pk)
         self.assertEqual(response.status_code, 200)
         self.assert_response_contains_record(response, self.record1)
+
+        # Tests that sending identical data doesn't cause the new versions to be created
+        original_num_versions = len(Version.objects.get_for_object(self.record1))
+        url = reverse("it_system_api_resource", kwargs={"system_id": self.record1.system_id})
+        response = self.client.post(
+            path=url,
+            data=json.dumps({"name": self.record1.name, "description": self.record1.description}),
+            secure=False,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        versions = Version.objects.get_for_object(self.record1)
+        self.assertEqual(len(versions), original_num_versions)
+
+        # Tests that identical data doesn't get included in version history comments
+        url = reverse("it_system_api_resource", kwargs={"system_id": self.record1.system_id})
+        response = self.client.post(
+            path=url,
+            data=json.dumps({"name": (self.record1.name + "_ADDED_VALUE"), "description": self.record1.description}),
+            secure=False,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        versions = Version.objects.get_for_object(self.record1)
+        self.assertIn("Name", versions[0].revision.get_comment())
+        self.assertNotIn("Description", versions[0].revision.get_comment())
 
     def test_contact_replace(self):
         """Test the ITSystemRecordAPIResource replace contact functionality"""

--- a/itsystems/utils.py
+++ b/itsystems/utils.py
@@ -189,7 +189,7 @@ def edit_record_from_dict(record, dict, user):
             # Create comment for version history
             change_log = "Changed via web request: "
             for field in dict.keys():
-                if field in original.keys():
+                if field in original.keys() and original[field] != incoming[field]:
                     change_log += record.__display_field__(field) + ", "
             comment = change_log[:-2] + "."
 

--- a/itsystems/views.py
+++ b/itsystems/views.py
@@ -34,7 +34,7 @@ class ITSystemsRegister(LoginRequiredMixin, ListView):
 
         # Filter out decommisioned and (if required) drafts
         excluded = ["Decommissioned"]
-        if not "show_drafts" in self.request.GET:
+        if "show_drafts" not in self.request.GET:
             excluded.append("Draft")
 
         # retrieve choice fields
@@ -87,7 +87,7 @@ class ITSystemsRegister(LoginRequiredMixin, ListView):
 
         # Filter out decommisioned and (if required) drafts
         excluded = ["Decommissioned"]
-        if not "show_drafts" in self.request.GET:
+        if "show_drafts" not in self.request.GET:
             excluded.append("Draft")
 
         # Filters queryset by chosen search values and filter values
@@ -169,10 +169,11 @@ class ImportRegisterChangesFromCSV(LoginRequiredMixin, PermissionRequiredMixin, 
             response = render(request, "admin/itsystems/itsystemrecord/upload_csv.html", context=results["validation"])
         return response
 
+
 # The below view is CSRF exempt as it's intended to be used by Freshservice without state.
 # The only possible malicious security implications is making edits of the register, which can all be rolled back with django-reversions.
 # Improvements to this are still being investigated.
-@method_decorator(csrf_exempt, name='dispatch')
+@method_decorator(csrf_exempt, name="dispatch")
 class ITSystemRecordAPIResource(View):
     """An API view that returns JSON of the IT System Register"""
 
@@ -190,6 +191,9 @@ class ITSystemRecordAPIResource(View):
             queryset = queryset.filter(system_id=kwargs["system_id"])
 
         register = [record.to_dict() for record in queryset]
+
+        if len(queryset) == 1:
+            register = register[0]
 
         response = JsonResponse(register, safe=False)
 


### PR DESCRIPTION
Changes:
- GET with search variable now returns exactly 1 records
- POST now only appends changing variables to the version history comment, instead of all fields included in the package.
- Tests adjusted to validate changes