### PR TITLE
fixed ITSR contact audit not detecting inactive accounts

### DIFF
--- a/itsystems/management/commands/it_systems_register_contact_notification.py
+++ b/itsystems/management/commands/it_systems_register_contact_notification.py
@@ -86,12 +86,13 @@ def _process_contact(flagged_users, record, field_name, user, logger):
     """
     If the user doesn't appear on the addressbook, the user is flagged.
     """
-    if user.account_type in DepartmentUser.ACCOUNT_TYPE_EXCLUDE:
+    if user.account_type in DepartmentUser.ACCOUNT_TYPE_EXCLUDE or user.active==False:
         system_str = str(record)
         user_str = str(user)
         status_str = user.get_account_type_display()
-        flagged_users.append({"system_name": system_str, "field_name": field_name, "user_email": user_str, "user_status": status_str})
-        logger.info(f"User Flagged - {system_str} | {field_name} | {user_str} | {status_str}")
+        active_str = str(user.active)
+        flagged_users.append({"system_name": system_str, "field_name": field_name, "user_email": user_str, "user_status": status_str, "active": active_str})
+        logger.info(f"User Flagged - {system_str} | {field_name} | {user_str} | {status_str} | Active: {active_str}")
 
 
 def _process_null(flagged_users, record, field_name, logger):
@@ -99,5 +100,5 @@ def _process_null(flagged_users, record, field_name, logger):
     Flags mandatory field as empty.
     """
     system_str = str(record)
-    flagged_users.append({"system_name": system_str, "field_name": field_name, "user_email": "EMPTY", "user_status": "EMPTY"})
-    logger.info(f"User Flagged - {system_str} | {field_name} | EMPTY | EMPTY")
+    flagged_users.append({"system_name": system_str, "field_name": field_name, "user_email": "EMPTY", "user_status": "EMPTY", "active": "N/A"})
+    logger.info(f"User Flagged - {system_str} | {field_name} | EMPTY | EMPTY | Active: N/A")

--- a/itsystems/notifications.py
+++ b/itsystems/notifications.py
@@ -59,12 +59,14 @@ def send_daily_audit_email(flagged_users):
 {flagged_user["system_name"]}
 {flagged_user["field_name"]}: {flagged_user["user_email"]}
 Account status: {flagged_user["user_status"]}
+Active?: {flagged_user["active"]}
 """
             html_content_body += f"""
 <ul>
 <li><b>{flagged_user["system_name"]}</b></li>
 <li>{flagged_user["field_name"]}: {flagged_user["user_email"]}</li>
 <li>Account status: {flagged_user["user_status"]}</li>
+<li>Active?: {flagged_user["active"]}</li>
 </ul>
 """
         # Appends new text to existing text body

--- a/itsystems/tests/test_commands.py
+++ b/itsystems/tests/test_commands.py
@@ -78,3 +78,10 @@ class CommandsTestCase(TestCase):
 
         msg = cmd.handle(send_email=True, return_msg=True)
         self.assertEqual(msg, None)
+
+        # Verify that the audit detects inactive accounts
+        record2.business_service_owner.active=False
+        record2.business_service_owner.save()
+        msg = cmd.handle(send_email=True, return_msg=True)
+        self.assertEqual(msg.body.count(str(record2)), 2)
+        self.assertEqual(msg.body.count(record2.business_service_owner.email), 2)

--- a/itsystems/tests/test_notifications.py
+++ b/itsystems/tests/test_notifications.py
@@ -37,12 +37,14 @@ class NotificationsTestCase(TestCase):
                 "field_name": "example_field1",
                 "user_email": "example_email1",
                 "user_status": "example_status1",
+                "active": "False",
             },
             {
                 "system_name": "example_sys2",
                 "field_name": "example_field2",
                 "user_email": "example_email2",
                 "user_status": "example_status2",
+                "active": "True",
             },
         ]
 
@@ -53,3 +55,4 @@ class NotificationsTestCase(TestCase):
             self.assertIn(user["field_name"], msg.body)
             self.assertIn(user["user_email"], msg.body)
             self.assertIn(user["user_status"], msg.body)
+            self.assertIn(f"Active?: {user["active"]}", msg.body)


### PR DESCRIPTION
Previously, the ITSR contact audit didn't check for inactive accounts.
Now it reports on this.